### PR TITLE
Option for adding timezone offset to initial date

### DIFF
--- a/source/javascripts/jquery.minical.js.coffee
+++ b/source/javascripts/jquery.minical.js.coffee
@@ -84,6 +84,7 @@ minical =
   move_on_resize: true
   read_only: true
   show_clear_link: false
+  add_timezone_offset: false
   appendCalendarTo: -> $('body')
   date_format: (date) ->
     [date.getMonth()+1, date.getDate(), date.getFullYear()].join("/")
@@ -267,11 +268,14 @@ minical =
       if attr and /^\d+$/.test(attr) then @[range] = new Date(+attr)
   detectInitialDate: ->
     initial_date = @$el.attr("data-minical-initial") || @$el.val()
-    if /^\d+$/.test(initial_date)
-      return new Date(+initial_date)
+    millis = if /^\d+$/.test(initial_date)
+      initial_date
     else if initial_date
-      return new Date(initial_date)
-    new Date()
+      Date.parse(initial_date)
+    else
+      new Date().getTime()
+    millis = parseInt(millis) + if @add_timezone_offset then (new Date().getTimezoneOffset() * 60 * 1000) else 0
+    new Date(millis)
   external:
     clear: ->
       mc = @data('minical')

--- a/source/javascripts/suite.coffee
+++ b/source/javascripts/suite.coffee
@@ -425,6 +425,15 @@ test "Option to display clear link", ->
   $input.shouldHaveValue("")
   tester.cal().shouldNotBe(":visible")
 
+test "Option to add browsers offset to parsed time", ->
+  opts =
+    add_timezone_offset: true
+  $(".calendar :text")
+    .attr("data-minical-initial", "2014-08-07T00:00:00Z")
+    .val("")
+  $el = tester.init(opts).focus()
+  $el.shouldHaveValue("8/7/2014")
+
 test "Initialize without writing to empty field automatically", ->
   opts =
     initialize_with_date: false


### PR DESCRIPTION
Per http://stackoverflow.com/questions/2587345/javascript-date-parse
the format "2014-11-14T00:00:00Z" parses the same way across browsers.

After using parse to get the milliseconds for a time we can add the
offset for the browser to ensure that the date displayed reflects
the date provided as an initial value.
