### PR TITLE
Fix the default trigger

### DIFF
--- a/source/javascripts/jquery.minical.js.coffee
+++ b/source/javascripts/jquery.minical.js.coffee
@@ -311,7 +311,7 @@ minical =
       @$el
         .on("focus.minical click.minical", => @$cal.trigger('show.minical'))
         .on("hide.minical", $.proxy(@hideCalendar, @))
-        .on("keydown.minical", (e) -> mc.preventKeystroke.call(mc, e))
+        .on("keydown.minical", (e) -> !mc.preventKeystroke.call(mc, e))
       @$cal
         .on("hide.minical", $.proxy(@hideCalendar, @))
         .on("show.minical", $.proxy(@showCalendar, @))


### PR DESCRIPTION
The code expects the @trigger value to be usable for things like:

```
    mc.$el.add(mc.$trigger).is(":focus")
```

But if the trigger is configured as null (as is the default),
the initTrigger() function will override @$trigger to be
$.noop, which is not usable in the above code line.

Therefore, the proper thing to do when trigger is configured to be
null is to set @$trigger to the minical DOM element itself.  That is what
this fix does.
