### PR TITLE
Fix keyboard date entry

### DIFF
--- a/source/javascripts/jquery.minical.js.coffee
+++ b/source/javascripts/jquery.minical.js.coffee
@@ -311,7 +311,7 @@ minical =
       @$el
         .on("focus.minical click.minical", => @$cal.trigger('show.minical'))
         .on("hide.minical", $.proxy(@hideCalendar, @))
-        .on("keydown.minical", (e) -> mc.preventKeystroke.call(mc, e))
+        .on("keydown.minical", (e) -> !mc.preventKeystroke.call(mc, e))
       @$cal
         .on("hide.minical", $.proxy(@hideCalendar, @))
         .on("show.minical", $.proxy(@showCalendar, @))


### PR DESCRIPTION
Minical was not allowing keyboard entry even when `read_only` was set to false.

The problem was that the `keydown.minical` event handler was mishandling the true/false value returned by
`preventKeyStroke()`.  This commit fixes that.