### PR TITLE
Fix the default trigger

### DIFF
--- a/source/javascripts/jquery.minical.js.coffee
+++ b/source/javascripts/jquery.minical.js.coffee
@@ -260,7 +260,7 @@ minical =
         .data("minical", @)
         .on("focus.minical click.minical", => @$cal.trigger('show.minical'))
     else
-      @$trigger = $.noop
+      @$trigger = @$el
       @align_to_trigger = false
   detectDataAttributeOptions: ->
     for range in ['from', 'to']


### PR DESCRIPTION
The code expects the @trigger value to be usable for things like:

        mc.$el.add(mc.$trigger).is(":focus")
    
But if the trigger is configured as null (as is the default),
the initTrigger() function will override @$trigger to be
$.noop, which is not usable in the above code line.
    
Therefore, the proper thing to do when trigger is configured to be
null is to set @$trigger to the minical DOM element itself.  That is what
this fix does.